### PR TITLE
Fixing implied internals

### DIFF
--- a/BadgeHub.podspec
+++ b/BadgeHub.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'BadgeHub'
-  s.version          = '0.1.0'
+  s.version          = '0.1.1'
   s.summary          = 'A way to quickly add a notification bedge icon to any view.'
 
 # This description is used to generate tags and improve search results.

--- a/BadgeHub/Classes/BadgeHub.swift
+++ b/BadgeHub/Classes/BadgeHub.swift
@@ -60,7 +60,7 @@ public class BadgeHub: NSObject {
     private var isIndeterminateMode = false
 
     // MARK: - SETUP
-    init(view: UIView) {
+    public init(view: UIView) {
         super.init()
 
         maxCount = 100000
@@ -76,7 +76,7 @@ public class BadgeHub: NSObject {
     //    }
 
     // Adjustment methods
-    func setView(_ view: UIView?, andCount startCount: Int) {
+    public func setView(_ view: UIView?, andCount startCount: Int) {
         curOrderMagnitude = 0
 
         let frame: CGRect? = view?.frame
@@ -152,22 +152,22 @@ public class BadgeHub: NSObject {
     }
 
     // Increases count by 1
-    func increment() {
+    public func increment() {
         increment(by: 1)
     }
 
     // Increases count by amount
-    func increment(by amount: Int) {
+    public func increment(by amount: Int) {
         count += amount
     }
 
     // Decreases count
-    func decrement() {
+    public func decrement() {
         decrement(by: 1)
     }
 
     // Decreases count by amount
-    func decrement(by amount: Int) {
+    public func decrement(by amount: Int) {
         if amount >= count {
             count = 0
             return
@@ -175,18 +175,18 @@ public class BadgeHub: NSObject {
         count -= amount
     }
 
-    func hideCount() {
+    public func hideCount() {
         countLabel?.isHidden = true
         isIndeterminateMode = true
     }
 
-    func showCount() {
+    public func showCount() {
         isIndeterminateMode = false
         checkZero()
     }
 
     // Animations
-    func pop() {
+    public func pop() {
         let height = baseFrame.size.height
         let width = baseFrame.size.width
         let popStartHeight: Float = Float(height * popStartRatio)
@@ -273,7 +273,7 @@ public class BadgeHub: NSObject {
         }
     }
 
-    func blink() {
+    public func blink() {
         self.setAlpha(alpha: Float(blinkAlpha))
 
         UIView.animate(withDuration: TimeInterval(blinkDuration), animations: {
@@ -290,7 +290,7 @@ public class BadgeHub: NSObject {
     }
 
     // Animation that jumps similar to OSX dock icons
-    func bump() {
+    public func bump() {
         if !initialCenter.equalTo(redCircle.center) {
             // canel previous animation
         }
@@ -315,7 +315,7 @@ public class BadgeHub: NSObject {
 
 
     // Set the count yourself
-    func setCount(_ newCount: Int) {
+    public func setCount(_ newCount: Int) {
         count = newCount
 
         var labelText = "\(NSNumber(value: count))"
@@ -330,11 +330,11 @@ public class BadgeHub: NSObject {
     }
 
     // Set the font of the label
-    func setCountLabel(_ font: UIFont?) {
+    public func setCountLabel(_ font: UIFont?) {
         countLabel?.font = font
     }
 
-    func countLabelFont() -> UIFont? {
+    public func countLabelFont() -> UIFont? {
         return countLabel?.font
     }
 

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes the following:
- #6 (Initializer not specifically marked public)
- Several methods that were implicitly interpreted as internal

Also bumps podspec to 0.1.1

Note to @jogendra: anything not explicitly marked `public` or `private` is interpreted by the compiler as `internal` :)